### PR TITLE
Add tests for solution parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # E-Archieves
+
+## Running Tests
+
+To run the unit tests, install the .NET 6 SDK and execute:
+
+```bash
+dotnet test
+```
+
+All tests are located under the `tests/` directory.

--- a/tests/E-Archieves.Tests/E-Archieves.Tests.csproj
+++ b/tests/E-Archieves.Tests/E-Archieves.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.Build" Version="17.8.0" />
+  </ItemGroup>
+</Project>

--- a/tests/E-Archieves.Tests/Tests/SolutionLoadTests.cs
+++ b/tests/E-Archieves.Tests/Tests/SolutionLoadTests.cs
@@ -1,0 +1,15 @@
+using Microsoft.Build.Construction;
+using Xunit;
+
+namespace E_Archieves.Tests;
+
+public class SolutionLoadTests
+{
+    [Fact]
+    public void Solution_can_be_parsed()
+    {
+        var solutionPath = Path.Combine("..", "..", "E-Archieves.sln");
+        var solution = SolutionFile.Parse(solutionPath);
+        Assert.NotNull(solution);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project under `tests/`
- parse `E-Archieves.sln` in a test
- document test execution in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1b4af4c83218b08c3a37f3e8b33