### PR TITLE
Fix comment typo in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,7 @@
 ###############################################################################
 # Set default behavior for command prompt diff.
 #
-# This is need for earlier builds of msysgit that does not have it on by
+# This is needed for earlier builds of msysgit that do not have it on by
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################


### PR DESCRIPTION
## Summary
- correct a typo in `.gitattributes`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e17bdb648321baa05e3660415756